### PR TITLE
Handle closed socket connections

### DIFF
--- a/lib/ws_sync_client.rb
+++ b/lib/ws_sync_client.rb
@@ -111,7 +111,7 @@ class WsSyncClient
 
     bytes = @socket.recv @max_recv
 
-    if bytes == ""
+    if bytes.empty?
       @socket.close
       @closed = true
       return :closed

--- a/lib/ws_sync_client.rb
+++ b/lib/ws_sync_client.rb
@@ -31,7 +31,7 @@ class WsSyncClient
 
   # Send a WebSocket frame.
   #
-  # @param [String] data the data to be sent
+  # @param [String] data the data to be sent or :closed if the socket is closed
   def send_frame(data)
     return :closed if @closed
 

--- a/test/test_ws_sync_client.rb
+++ b/test/test_ws_sync_client.rb
@@ -69,21 +69,20 @@ describe 'WsSync' do
       @ws.close
     end
 
-    it 'causes #send_frame to raise an exception' do
+    it 'causes #send_frame to retur :closed' do
       @ws.close
-      lambda {
-        @ws.send_frame JSON.dump(cmd: 'echo', seq: 1, data: 'Hello world!')
-      }.must_raise IOError
+
+      result = @ws.send_frame JSON.dump(cmd: 'echo', seq: 1, data: 'Hello world!')
+      result.must_equal :closed
     end
 
-    it 'causes #recv_frame to raise an exception' do
+    it 'causes #recv_frame to return :closed' do
       parsed = JSON.parse @ws.recv_frame
       parsed['handshake'].must_equal 'completed'
 
       @ws.close
-      lambda {
-        @ws.recv_frame
-      }.must_raise IOError
+      result = @ws.recv_frame
+      result.must_equal :closed
     end
   end
 
@@ -97,10 +96,9 @@ describe 'WsSync' do
                                reason: 'testing server-side closing')
     end
 
-    it '#recv_frame raises an exception' do
-      lambda {
-        @ws.recv_frame
-      }.must_raise IOError
+    it '#recv_frame returns :closed' do
+      result = @ws.recv_frame
+      result.must_equal :closed
     end
 
     it '#close does not crash' do

--- a/test/test_ws_sync_client.rb
+++ b/test/test_ws_sync_client.rb
@@ -69,7 +69,7 @@ describe 'WsSync' do
       @ws.close
     end
 
-    it 'causes #send_frame to retur :closed' do
+    it 'causes #send_frame to return :closed' do
       @ws.close
 
       result = @ws.send_frame JSON.dump(cmd: 'echo', seq: 1, data: 'Hello world!')


### PR DESCRIPTION
This MR allows to track closed socket connections, so we can act generating an error if we expect to get new frames and there is no connection open.

This is the first step to fix issues with closed connections in webkit_remote that causes infinite loops in recv_frame function of this gem.